### PR TITLE
Change set-output to GITHUB_OUTPUT

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,6 +4,6 @@ set -eo pipefail
 
 npx depcheck@"${INPUT_VERSION}" --ignores="${INPUT_IGNORES}" "${INPUT_DIR}" 2>&1 && exit_status=$? || exit_status=$?
 
-echo "exit_code=$exit_status" >> $GITHUB_OUTPUT
+echo "exit_code=$exit_status" >> "$GITHUB_OUTPUT"
 
 exit $exit_status

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,6 +4,6 @@ set -eo pipefail
 
 npx depcheck@"${INPUT_VERSION}" --ignores="${INPUT_IGNORES}" "${INPUT_DIR}" 2>&1 && exit_status=$? || exit_status=$?
 
-echo "::set-output name=exit_code::$exit_status"
+echo "exit_code=$exit_status" >> $GITHUB_OUTPUT
 
 exit $exit_status


### PR DESCRIPTION
This fixes the following warning that is output when using this action:
```
Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```